### PR TITLE
Refactoring of View

### DIFF
--- a/Project/core/src/main/java/View/screen/GameScreen.java
+++ b/Project/core/src/main/java/View/screen/GameScreen.java
@@ -117,96 +117,14 @@ public class GameScreen implements Screen {
         root.row();
         root.add(actionBar).expandX().fillX().bottom().height(stage.getViewport().getWorldHeight() * 0.1f);
 
-        String[] actions = {"Move", "Reveal" };
-        for (String action : actions) {
-            TextButton actionButton = new TextButton(action, skin);
-            actionButtons.add(actionButton);
-            actionBar.add(actionButton).expandX();
-
-            actionButton.addListener(new ChangeListener() {
-                @Override
-                public void changed(ChangeEvent event, Actor actor) {
-                    askAction();
-                }
-            });
-        }
         // Create an Ask-button if the cell is not a temple
         AbstractCell cell = gameController.getGame().getBoard().getCell(0, 0);
         if (cell.getClass().equals(NormalCell.class)) {
             NormalCell normalCell = (NormalCell) cell;
-            AskButton askButton = new AskButton("Ask", skin, stage, selectedFeature, gameController, normalCell);
+            AskButton askButton = new AskButton(skin, stage, selectedFeature, gameController, normalCell);
             actionButtons.add(askButton);
             actionBar.add(askButton);
         }
-    }
-
-    private void askAction() {
-        Window askActionWindow = createAskActionWindow("Ask Action", "Which feature do you want to ask?");
-        stage.addActor(askActionWindow);
-    }
-
-    private Window createAskActionWindow(String title, String message) {
-        Window askWindow = new Window(title, skin);
-        askWindow.setMovable(false);
-        askWindow.setResizable(false);
-        askWindow.setModal(true);
-
-        Button closeButton = new Button(skin, "close");
-        closeButton.addListener(new ChangeListener() {
-            @Override
-            public void changed(ChangeEvent event, Actor actor) {
-                askWindow.remove();
-            }
-        });
-        askWindow.getTitleTable().add(closeButton).padLeft(10).padTop(2).right();
-
-        Label messageLabel = new Label(message, skin);
-        messageLabel.setFontScale(2f);
-        askWindow.add(messageLabel).pad(20).row();
-
-        Table buttonTable = new Table();
-
-        // TODO: get the feature from the model
-        TextButton featureButton1 = new TextButton("Feature 1", skin);
-        featureButton1.addListener(new ChangeListener() {
-            @Override
-            public void changed(ChangeEvent event, Actor actor) {
-                // get the selected feature
-                selectedFeature = "Feature 1";
-            }
-        });
-        buttonTable.add(featureButton1).padRight(20).padBottom(10);
-
-        // TODO: get the feature from the model
-        TextButton featureButton2 = new TextButton("Feature 2", skin);
-        featureButton2.addListener(new ChangeListener() {
-            @Override
-            public void changed(ChangeEvent event, Actor actor) {
-                selectedFeature = "Feature 2";
-            }
-        });
-        buttonTable.add(featureButton2).padBottom(10);
-
-        askWindow.add(buttonTable).colspan(2).center().row();
-
-        TextButton confirmButton = new TextButton("Confirm", skin);
-        confirmButton.addListener(new ChangeListener() {
-            @Override
-            public void changed(ChangeEvent event, Actor actor) {
-                // TODO:send the selected feature to the game controller
-                System.out.println("Feature selected" + selectedFeature);
-                gameController.newTurn();
-                askWindow.remove();
-            }
-        });
-        askWindow.add(confirmButton).colspan(2).padTop(10).center().row();
-
-        askWindow.pack();
-        askWindow.setSize(500, 200);
-        askWindow.setPosition(stage.getWidth() / 2 - askWindow.getWidth() / 2,
-                stage.getHeight() / 2 - askWindow.getHeight() / 2);
-
-        return askWindow;
     }
 
     @Override

--- a/Project/core/src/main/java/View/screen/GameScreen.java
+++ b/Project/core/src/main/java/View/screen/GameScreen.java
@@ -13,10 +13,8 @@ import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.viewport.ScreenViewport;
 
-import Model.AbstractCell;
 import Model.Board;
 import Model.Csv;
-import Model.NormalCell;
 import Model.RougeAgent;
 import View.buildingBlocks.VisualBoard;
 import View.screen.GameScreenComponents.AskButton;
@@ -113,7 +111,7 @@ public class GameScreen implements Screen {
         root.row();
         root.add(actionBar).expandX().fillX().bottom().height(stage.getViewport().getWorldHeight() * 0.1f);
 
-        AskButton askButton = new AskButton(skin, stage, gameController);
+        AskButton askButton = new AskButton(gameController, skin);
         actionButtons.add(askButton);
         actionBar.add(askButton);
     }

--- a/Project/core/src/main/java/View/screen/GameScreen.java
+++ b/Project/core/src/main/java/View/screen/GameScreen.java
@@ -221,7 +221,7 @@ public class GameScreen implements Screen {
         Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
         stage.act(delta);
         stage.draw();
-        playerBar.update();
+        //playerBar.update();
         turnBar.updateTurnbar();
     }
 

--- a/Project/core/src/main/java/View/screen/GameScreen.java
+++ b/Project/core/src/main/java/View/screen/GameScreen.java
@@ -4,10 +4,8 @@ import Controller.ActionController;
 import Controller.GameController;
 import View.buildingBlocks.MindMGMTStage;
 import com.badlogic.gdx.Screen;
-import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Texture;
-import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.scenes.scene2d.ui.*;
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
 import com.badlogic.gdx.utils.Array;
@@ -26,7 +24,6 @@ import com.badlogic.gdx.scenes.scene2d.Actor;
 import View.screen.GameScreenComponents.TurnBar;
 
 public class GameScreen implements Screen {
-    private final MindMGMT application;
     private final GameController gameController;
     private final ActionController actionController;
     private final MindMGMTStage stage;
@@ -38,7 +35,6 @@ public class GameScreen implements Screen {
     private final SettingWindow settingWindow;
 
     public GameScreen(MindMGMT application) {
-        this.application = application;
 
         this.stage = new MindMGMTStage(new ScreenViewport(), application.assets);
         this.skin = application.skin;

--- a/Project/core/src/main/java/View/screen/GameScreen.java
+++ b/Project/core/src/main/java/View/screen/GameScreen.java
@@ -113,14 +113,9 @@ public class GameScreen implements Screen {
         root.row();
         root.add(actionBar).expandX().fillX().bottom().height(stage.getViewport().getWorldHeight() * 0.1f);
 
-        // Create an Ask-button if the cell is not a temple
-        AbstractCell cell = gameController.getGame().getBoard().getCell(0, 0);
-        if (cell.getClass().equals(NormalCell.class)) {
-            NormalCell normalCell = (NormalCell) cell;
-            AskButton askButton = new AskButton(skin, stage, gameController, normalCell);
-            actionButtons.add(askButton);
-            actionBar.add(askButton);
-        }
+        AskButton askButton = new AskButton(skin, stage, gameController);
+        actionButtons.add(askButton);
+        actionBar.add(askButton);
     }
 
     @Override

--- a/Project/core/src/main/java/View/screen/GameScreen.java
+++ b/Project/core/src/main/java/View/screen/GameScreen.java
@@ -36,14 +36,11 @@ public class GameScreen implements Screen {
     private final Texture boardTexture;
     private final PlayerBar playerBar;
     private final TurnBar turnBar;
-    //private Label timeTracker;
     private final Array<TextButton> actionButtons = new Array<TextButton>();
     private final SettingWindow settingWindow;
-    private String selectedFeature;
 
     public GameScreen(MindMGMT application) {
         this.application = application;
-        this.selectedFeature = "";
 
         this.stage = new MindMGMTStage(new ScreenViewport(), application.assets);
         this.skin = application.skin;
@@ -81,7 +78,6 @@ public class GameScreen implements Screen {
                 stage.addActor(settingWindow);
             }
         });
-
     }
 
     private void setupPlayerBar(Table root) {
@@ -121,14 +117,13 @@ public class GameScreen implements Screen {
         AbstractCell cell = gameController.getGame().getBoard().getCell(0, 0);
         if (cell.getClass().equals(NormalCell.class)) {
             NormalCell normalCell = (NormalCell) cell;
-            AskButton askButton = new AskButton(skin, stage, selectedFeature, gameController, normalCell);
+            AskButton askButton = new AskButton(skin, stage, gameController, normalCell);
             actionButtons.add(askButton);
             actionBar.add(askButton);
         }
     }
 
     @Override
-
     public void show() {
     }
 

--- a/Project/core/src/main/java/View/screen/GameScreen.java
+++ b/Project/core/src/main/java/View/screen/GameScreen.java
@@ -221,7 +221,6 @@ public class GameScreen implements Screen {
         Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
         stage.act(delta);
         stage.draw();
-        //playerBar.update();
         turnBar.updateTurnbar();
     }
 

--- a/Project/core/src/main/java/View/screen/GameScreenComponents/AskButton.java
+++ b/Project/core/src/main/java/View/screen/GameScreenComponents/AskButton.java
@@ -1,25 +1,15 @@
 package View.screen.GameScreenComponents;
 
-import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.g2d.Batch;
-import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.Stage;
-import com.badlogic.gdx.scenes.scene2d.ui.Button;
-import com.badlogic.gdx.scenes.scene2d.ui.ImageButton;
-import com.badlogic.gdx.scenes.scene2d.ui.Label;
 import com.badlogic.gdx.scenes.scene2d.ui.Skin;
-import com.badlogic.gdx.scenes.scene2d.ui.Table;
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
-import com.badlogic.gdx.scenes.scene2d.ui.Window;
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
-import com.badlogic.gdx.scenes.scene2d.utils.TextureRegionDrawable;
 
 import Controller.GameController;
 import Model.AbstractCell;
-import Model.Feature;
 import Model.NormalCell;
-import View.buildingBlocks.VisualCell;
 
 public class AskButton extends TextButton {
 
@@ -37,15 +27,16 @@ public class AskButton extends TextButton {
         this.gameController = gameController;
 
         // TODO: This should probbly be in controller
-        this.cell = gameController.getGame().getBoard().getCell(2, 2);
-        
+        this.cell = gameController.getGame().getBoard().getCell(0, 0);
+
         this.addListener(new ChangeListener() {
             @Override
             public void changed(ChangeEvent event, Actor actor) {
-                Window askActionWindow = createAskActionWindow("Ask Action", "Which feature do you want to ask about?");
+                NormalCell normalCell = (NormalCell) cell;
+                AskWindow askActionWindow = new AskWindow(skin, normalCell, stage);
                 stage.addActor(askActionWindow);
             }
-        });        
+        });
     }
 
     @Override
@@ -57,106 +48,18 @@ public class AskButton extends TextButton {
             return null;
         }
     }
-    
+
     @Override
     public void draw(Batch batch, float parentAlpha) {
         // Enable the button
         if (cell.getClass().equals(NormalCell.class)) {
             this.setDisabled(false);
-        // Disable the button
+            // Disable the button
         } else {
             this.setColor(0.8f, 0.8f, 0.8f, 1f);
             this.setDisabled(true);
-        } 
+        }
         super.draw(batch, parentAlpha); // Important
     }
 
-    // Create a new window
-    private Window createAskActionWindow(String title, String message) {
-        // Create the window
-        Window askWindow = new Window(title, skin);
-        askWindow.setMovable(false);
-        askWindow.setResizable(false);
-        askWindow.setModal(true);
-
-        // Create a button for closing the window
-        Button closeButton = new Button(skin, "close");
-        closeButton.addListener(new ChangeListener() {
-            @Override
-            public void changed(ChangeEvent event, Actor actor) {
-                askWindow.remove();
-            }
-        });
-
-        // Add the close button to the window
-        askWindow.getTitleTable().add(closeButton).padLeft(10).padTop(2).right();
-
-        // Add the message to the window
-        Label messageLabel = new Label(message, skin);
-        askWindow.add(messageLabel).pad(20).row();
-
-        // Create a table for the feature buttons
-        Table buttonTable = new Table();
-
-        // Create a button for the first feature
-        NormalCell normalCell = (NormalCell) cell;
-        Feature[] features = normalCell.getFeatures();
-        ImageButton[] selectedButton = {null}; // To track the currently selected button
-
-        for (Feature feature : features) {
-            VisualCell visualCell = new VisualCell(cell);
-            TextureRegion featureTexture = visualCell.fetchFeature(feature);
-            TextureRegionDrawable drawable = new TextureRegionDrawable(featureTexture);
-            drawable.setMinWidth(100);
-            drawable.setMinHeight(100);
-            ImageButton.ImageButtonStyle buttonStyle = new ImageButton.ImageButtonStyle();
-            buttonStyle.up = drawable;
-            buttonStyle.down = drawable.tint(Color.BROWN);
-            ImageButton featureButton = new ImageButton(buttonStyle);
-            stage.addActor(featureButton);
-
-            featureButton.addListener(new ChangeListener() {
-                @Override
-                public void changed(ChangeEvent event, Actor actor) {
-                    // Resize previously selected button back to normal
-                    if (selectedButton[0] != null) {
-                        selectedButton[0].setSize(100, 100); // Reset size
-                        // selectedButton[0].addAction(Action.fadeIn());
-                    }
-
-                    // Set the newly selected button
-                    selectedButton[0] = featureButton;
-                    selectedFeature = feature.name();
-
-                    // Increase the size of the selected button
-                    featureButton.setSize(120, 120); // New size for the selected button
-
-                    selectedFeature = feature.name();
-                }
-            });
-            buttonTable.add(featureButton).padRight(20).padBottom(5);
-        }
-
-        // Add feature buttons to the window
-        askWindow.add(buttonTable).colspan(2).center().row();
-
-        TextButton confirmButton = new TextButton("Confirm", skin);
-        confirmButton.addListener(new ChangeListener() {
-            @Override
-            public void changed(ChangeEvent event, Actor actor) {
-                // TODO:send the selected feature to the game controller
-                System.out.println("Feature selected" + selectedFeature);
-                gameController.newTurn();
-                askWindow.remove();
-            }
-        });
-        askWindow.add(confirmButton).colspan(2).padTop(10).center().row();
-
-        askWindow.pack();
-        askWindow.setSize(500, 300);
-        askWindow.setPosition(stage.getWidth() / 2 - askWindow.getWidth() / 2,
-                stage.getHeight() / 2 - askWindow.getHeight() / 2);
-
-        return askWindow;
-    }
 }

--- a/Project/core/src/main/java/View/screen/GameScreenComponents/AskButton.java
+++ b/Project/core/src/main/java/View/screen/GameScreenComponents/AskButton.java
@@ -27,10 +27,10 @@ public class AskButton extends TextButton {
     GameController gameController;
     NormalCell cell;
 
-    public AskButton(String name, Skin skin, Stage stage, String selectedFeature, GameController gameController,
+    public AskButton(Skin skin, Stage stage, String selectedFeature, GameController gameController,
             NormalCell cell) {
 
-        super(name, skin);
+        super("Ask", skin);
         this.stage = stage;
         this.skin = skin;
         this.gameController = gameController;

--- a/Project/core/src/main/java/View/screen/GameScreenComponents/AskButton.java
+++ b/Project/core/src/main/java/View/screen/GameScreenComponents/AskButton.java
@@ -1,6 +1,7 @@
 package View.screen.GameScreenComponents;
 
 import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.g2d.Batch;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.Stage;
@@ -15,6 +16,7 @@ import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
 import com.badlogic.gdx.scenes.scene2d.utils.TextureRegionDrawable;
 
 import Controller.GameController;
+import Model.AbstractCell;
 import Model.Feature;
 import Model.NormalCell;
 import View.buildingBlocks.VisualCell;
@@ -25,23 +27,48 @@ public class AskButton extends TextButton {
     Skin skin;
     String selectedFeature;
     GameController gameController;
-    NormalCell cell;
+    AbstractCell cell;
 
-    public AskButton(Skin skin, Stage stage, GameController gameController, NormalCell cell) {
+    public AskButton(Skin skin, Stage stage, GameController gameController) {
 
         super("Ask", skin);
         this.stage = stage;
         this.skin = skin;
         this.gameController = gameController;
-        this.cell = cell;
 
+        // TODO: This should probbly be in controller
+        this.cell = gameController.getGame().getBoard().getCell(2, 2);
+        
         this.addListener(new ChangeListener() {
             @Override
             public void changed(ChangeEvent event, Actor actor) {
                 Window askActionWindow = createAskActionWindow("Ask Action", "Which feature do you want to ask about?");
                 stage.addActor(askActionWindow);
             }
-        });
+        });        
+    }
+
+    @Override
+    public Actor hit(float x, float y, boolean touchable) {
+        // This override prevents the button from being clickable when disabled
+        if (cell.getClass().equals(NormalCell.class)) {
+            return super.hit(x, y, touchable);
+        } else {
+            return null;
+        }
+    }
+    
+    @Override
+    public void draw(Batch batch, float parentAlpha) {
+        // Enable the button
+        if (cell.getClass().equals(NormalCell.class)) {
+            this.setDisabled(false);
+        // Disable the button
+        } else {
+            this.setColor(0.8f, 0.8f, 0.8f, 1f);
+            this.setDisabled(true);
+        } 
+        super.draw(batch, parentAlpha); // Important
     }
 
     // Create a new window
@@ -72,8 +99,8 @@ public class AskButton extends TextButton {
         Table buttonTable = new Table();
 
         // Create a button for the first feature
-
-        Feature[] features = cell.getFeatures();
+        NormalCell normalCell = (NormalCell) cell;
+        Feature[] features = normalCell.getFeatures();
         ImageButton[] selectedButton = {null}; // To track the currently selected button
 
         for (Feature feature : features) {

--- a/Project/core/src/main/java/View/screen/GameScreenComponents/AskButton.java
+++ b/Project/core/src/main/java/View/screen/GameScreenComponents/AskButton.java
@@ -27,8 +27,7 @@ public class AskButton extends TextButton {
     GameController gameController;
     NormalCell cell;
 
-    public AskButton(Skin skin, Stage stage, String selectedFeature, GameController gameController,
-            NormalCell cell) {
+    public AskButton(Skin skin, Stage stage, GameController gameController, NormalCell cell) {
 
         super("Ask", skin);
         this.stage = stage;

--- a/Project/core/src/main/java/View/screen/GameScreenComponents/AskButton.java
+++ b/Project/core/src/main/java/View/screen/GameScreenComponents/AskButton.java
@@ -3,7 +3,6 @@ package View.screen.GameScreenComponents;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.g2d.Batch;
 import com.badlogic.gdx.scenes.scene2d.Actor;
-import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.scenes.scene2d.ui.Skin;
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;

--- a/Project/core/src/main/java/View/screen/GameScreenComponents/AskButton.java
+++ b/Project/core/src/main/java/View/screen/GameScreenComponents/AskButton.java
@@ -1,5 +1,6 @@
 package View.screen.GameScreenComponents;
 
+import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.g2d.Batch;
 import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.Stage;
@@ -13,18 +14,11 @@ import Model.NormalCell;
 
 public class AskButton extends TextButton {
 
-    Stage stage;
-    Skin skin;
-    String selectedFeature;
-    GameController gameController;
-    AbstractCell cell;
+    private AbstractCell cell;
 
-    public AskButton(Skin skin, Stage stage, GameController gameController) {
+    public AskButton(GameController gameController, Skin skin) {
 
         super("Ask", skin);
-        this.stage = stage;
-        this.skin = skin;
-        this.gameController = gameController;
 
         // TODO: This should probbly be in controller
         this.cell = gameController.getGame().getBoard().getCell(0, 0);
@@ -33,8 +27,11 @@ public class AskButton extends TextButton {
             @Override
             public void changed(ChangeEvent event, Actor actor) {
                 NormalCell normalCell = (NormalCell) cell;
-                AskWindow askActionWindow = new AskWindow(skin, normalCell, stage);
-                stage.addActor(askActionWindow);
+                AskWindow askActionWindow = new AskWindow(skin, normalCell);
+                askActionWindow.setPosition(
+                    Gdx.graphics.getWidth() / 2 - askActionWindow.getWidth() / 2,
+                    Gdx.graphics.getHeight() / 2 - askActionWindow.getHeight() / 2);                
+                actor.getStage().addActor(askActionWindow);
             }
         });
     }

--- a/Project/core/src/main/java/View/screen/GameScreenComponents/AskWindow.java
+++ b/Project/core/src/main/java/View/screen/GameScreenComponents/AskWindow.java
@@ -1,0 +1,115 @@
+package View.screen.GameScreenComponents;
+
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.g2d.TextureRegion;
+import com.badlogic.gdx.scenes.scene2d.Actor;
+import com.badlogic.gdx.scenes.scene2d.Stage;
+import com.badlogic.gdx.scenes.scene2d.ui.Button;
+import com.badlogic.gdx.scenes.scene2d.ui.ImageButton;
+import com.badlogic.gdx.scenes.scene2d.ui.Label;
+import com.badlogic.gdx.scenes.scene2d.ui.Table;
+import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
+import com.badlogic.gdx.scenes.scene2d.ui.Window;
+import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
+import com.badlogic.gdx.scenes.scene2d.utils.TextureRegionDrawable;
+import com.badlogic.gdx.scenes.scene2d.ui.Skin;
+
+import Model.Feature;
+import Model.NormalCell;
+import View.buildingBlocks.VisualCell;
+
+
+public class AskWindow extends Window {
+
+    String selectedFeature;
+
+    public AskWindow(Skin skin, NormalCell cell, Stage stage) {
+        super("this", skin);
+        // Create the window
+        this.setMovable(false);
+        this.setResizable(false);
+        this.setModal(true);
+
+        // Create a button for closing the window
+        Button closeButton = new Button(skin, "close");
+        closeButton.addListener(new ChangeListener() {
+            @Override
+            public void changed(ChangeEvent event, Actor actor) {
+                remove();
+            }
+        });
+
+        // Add the close button to the window
+        this.getTitleTable().add(closeButton).padLeft(10).padTop(2).right();
+
+        // Add the message to the window
+        Label messageLabel = new Label("Which feature do you want to ask about?", skin);
+        this.add(messageLabel).pad(20).row();
+
+        // Create a table for the feature buttons
+        Table buttonTable = new Table();
+
+        // Create a button for the first feature
+        Feature[] features = cell.getFeatures();
+        ImageButton[] selectedButton = { null }; // To track the currently selected button
+
+        for (Feature feature : features) {
+            VisualCell visualCell = new VisualCell(cell);
+            TextureRegion featureTexture = visualCell.fetchFeature(feature);
+            TextureRegionDrawable drawable = new TextureRegionDrawable(featureTexture);
+            drawable.setMinWidth(100);
+            drawable.setMinHeight(100);
+            ImageButton.ImageButtonStyle buttonStyle = new ImageButton.ImageButtonStyle();
+            buttonStyle.up = drawable;
+            buttonStyle.down = drawable.tint(Color.BROWN);
+            ImageButton featureButton = new ImageButton(buttonStyle);
+            stage.addActor(featureButton);
+
+            featureButton.addListener(new ChangeListener() {
+                @Override
+                public void changed(ChangeEvent event, Actor actor) {
+                    // Resize previously selected button back to normal
+                    if (selectedButton[0] != null) {
+                        selectedButton[0].setSize(100, 100); // Reset size
+                        // selectedButton[0].addAction(Action.fadeIn());
+                    }
+
+                    // Set the newly selected button
+                    selectedButton[0] = featureButton;
+                    selectedFeature = feature.name();
+
+                    // Increase the size of the selected button
+                    featureButton.setSize(120, 120); // New size for the selected button
+
+                    selectedFeature = feature.name();
+                }
+            });
+            buttonTable.add(featureButton).padRight(20).padBottom(5);
+        }
+
+        // Add feature buttons to the window
+        this.add(buttonTable).colspan(2).center().row();
+
+        TextButton confirmButton = new TextButton("Confirm", skin);
+        confirmButton.addListener(new ChangeListener() {
+            @Override
+            public void changed(ChangeEvent event, Actor actor) {
+                // TODO: Send the selected feature to the game controller
+                System.out.println("Feature selected" + selectedFeature);
+                remove();
+            }
+        });
+        this.add(confirmButton).colspan(2).padTop(10).center().row();
+
+        this.pack();
+        this.setSize(500, 300);
+        this.setPosition(stage.getWidth() / 2 - this.getWidth() / 2,
+                stage.getHeight() / 2 - this.getHeight() / 2);
+
+    }
+
+    @Override
+    public boolean remove() {
+        return super.remove();
+    }
+}

--- a/Project/core/src/main/java/View/screen/GameScreenComponents/AskWindow.java
+++ b/Project/core/src/main/java/View/screen/GameScreenComponents/AskWindow.java
@@ -1,6 +1,7 @@
 package View.screen.GameScreenComponents;
 
 import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.g2d.Batch;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.ui.Button;
@@ -20,6 +21,8 @@ import View.buildingBlocks.VisualCell;
 public class AskWindow extends Window {
 
     String selectedFeature;
+    ImageButton selectedFeatureButton;
+    Table buttonTable;
 
     public AskWindow(Skin skin, NormalCell cell) {
         super("Ask Win", skin);
@@ -27,6 +30,7 @@ public class AskWindow extends Window {
         this.setMovable(false);
         this.setResizable(false);
         this.setModal(true);
+        this.buttonTable = new Table(); // Create a table for the feature buttons
 
         // Create a button for closing the window
         Button closeButton = new Button(skin, "close");
@@ -44,12 +48,8 @@ public class AskWindow extends Window {
         Label messageLabel = new Label("Which feature do you want to ask about?", skin);
         this.add(messageLabel).pad(20).row();
 
-        // Create a table for the feature buttons
-        Table buttonTable = new Table();
-
         // Create a button for the first feature
         Feature[] features = cell.getFeatures();
-        ImageButton[] selectedButton = { null }; // To track the currently selected button
 
         for (Feature feature : features) {
             VisualCell visualCell = new VisualCell(cell);
@@ -65,19 +65,7 @@ public class AskWindow extends Window {
             featureButton.addListener(new ChangeListener() {
                 @Override
                 public void changed(ChangeEvent event, Actor actor) {
-                    // Resize previously selected button back to normal
-                    if (selectedButton[0] != null) {
-                        selectedButton[0].setSize(100, 100); // Reset size
-                        // selectedButton[0].addAction(Action.fadeIn());
-                    }
-
-                    // Set the newly selected button
-                    selectedButton[0] = featureButton;
-                    selectedFeature = feature.name();
-
-                    // Increase the size of the selected button
-                    featureButton.setSize(120, 120); // New size for the selected button
-
+                    selectedFeatureButton = featureButton;
                     selectedFeature = feature.name();
                 }
             });
@@ -100,5 +88,18 @@ public class AskWindow extends Window {
 
         this.pack();
         this.setSize(500, 300);
+    }
+
+    @Override
+    public void draw(Batch batch, float parentAlpha) {
+        // Reset size for all ImageButtons
+        for (Actor actor : this.buttonTable.getChildren()) {
+            ((ImageButton)actor).setSize(100, 100);
+        }
+        // Increase the size of the selected button
+        if (selectedFeatureButton != null) {
+            selectedFeatureButton.setSize(120, 120);
+        } 
+        super.draw(batch, parentAlpha); // Important
     }
 }

--- a/Project/core/src/main/java/View/screen/GameScreenComponents/AskWindow.java
+++ b/Project/core/src/main/java/View/screen/GameScreenComponents/AskWindow.java
@@ -17,13 +17,12 @@ import Model.Feature;
 import Model.NormalCell;
 import View.buildingBlocks.VisualCell;
 
-
 public class AskWindow extends Window {
 
     String selectedFeature;
 
     public AskWindow(Skin skin, NormalCell cell) {
-        super("Ask Window", skin);
+        super("Ask Win", skin);
         // Create the window
         this.setMovable(false);
         this.setResizable(false);
@@ -34,7 +33,7 @@ public class AskWindow extends Window {
         closeButton.addListener(new ChangeListener() {
             @Override
             public void changed(ChangeEvent event, Actor actor) {
-                remove();
+                actor.getParent().remove();
             }
         });
 
@@ -94,17 +93,12 @@ public class AskWindow extends Window {
             public void changed(ChangeEvent event, Actor actor) {
                 // TODO: Send the selected feature to the game controller
                 System.out.println("Feature selected" + selectedFeature);
-                remove();
+                actor.getParent().remove();
             }
         });
         this.add(confirmButton).colspan(2).padTop(10).center().row();
 
         this.pack();
         this.setSize(500, 300);
-    }
-
-    @Override
-    public boolean remove() {
-        return super.remove();
     }
 }

--- a/Project/core/src/main/java/View/screen/GameScreenComponents/AskWindow.java
+++ b/Project/core/src/main/java/View/screen/GameScreenComponents/AskWindow.java
@@ -3,7 +3,6 @@ package View.screen.GameScreenComponents;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.scenes.scene2d.Actor;
-import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.scenes.scene2d.ui.Button;
 import com.badlogic.gdx.scenes.scene2d.ui.ImageButton;
 import com.badlogic.gdx.scenes.scene2d.ui.Label;
@@ -23,8 +22,8 @@ public class AskWindow extends Window {
 
     String selectedFeature;
 
-    public AskWindow(Skin skin, NormalCell cell, Stage stage) {
-        super("this", skin);
+    public AskWindow(Skin skin, NormalCell cell) {
+        super("Ask Window", skin);
         // Create the window
         this.setMovable(false);
         this.setResizable(false);
@@ -63,7 +62,6 @@ public class AskWindow extends Window {
             buttonStyle.up = drawable;
             buttonStyle.down = drawable.tint(Color.BROWN);
             ImageButton featureButton = new ImageButton(buttonStyle);
-            stage.addActor(featureButton);
 
             featureButton.addListener(new ChangeListener() {
                 @Override
@@ -103,9 +101,6 @@ public class AskWindow extends Window {
 
         this.pack();
         this.setSize(500, 300);
-        this.setPosition(stage.getWidth() / 2 - this.getWidth() / 2,
-                stage.getHeight() / 2 - this.getHeight() / 2);
-
     }
 
     @Override

--- a/Project/core/src/main/java/View/screen/GameScreenComponents/AskWindow.java
+++ b/Project/core/src/main/java/View/screen/GameScreenComponents/AskWindow.java
@@ -31,13 +31,14 @@ public class AskWindow extends Window {
         this.setResizable(false);
         this.setModal(true);
         this.buttonTable = new Table(); // Create a table for the feature buttons
+        this.add(buttonTable).colspan(2).center().row();
 
         // Create a button for closing the window
         Button closeButton = new Button(skin, "close");
         closeButton.addListener(new ChangeListener() {
             @Override
             public void changed(ChangeEvent event, Actor actor) {
-                actor.getParent().remove();
+                actor.getParent().remove(); // Closes the window
             }
         });
 
@@ -52,16 +53,19 @@ public class AskWindow extends Window {
         Feature[] features = cell.getFeatures();
 
         for (Feature feature : features) {
+            // Get the feature image
             VisualCell visualCell = new VisualCell(cell);
             TextureRegion featureTexture = visualCell.fetchFeature(feature);
+            // Create an ImageButton based on the feature image
             TextureRegionDrawable drawable = new TextureRegionDrawable(featureTexture);
             drawable.setMinWidth(100);
             drawable.setMinHeight(100);
             ImageButton.ImageButtonStyle buttonStyle = new ImageButton.ImageButtonStyle();
             buttonStyle.up = drawable;
-            buttonStyle.down = drawable.tint(Color.BROWN);
+            buttonStyle.down = drawable.tint(Color.BROWN); // Tint the button when it's pressed
             ImageButton featureButton = new ImageButton(buttonStyle);
 
+            // Update the selected feature when the button is pressed
             featureButton.addListener(new ChangeListener() {
                 @Override
                 public void changed(ChangeEvent event, Actor actor) {
@@ -72,20 +76,16 @@ public class AskWindow extends Window {
             buttonTable.add(featureButton).padRight(20).padBottom(5);
         }
 
-        // Add feature buttons to the window
-        this.add(buttonTable).colspan(2).center().row();
-
         TextButton confirmButton = new TextButton("Confirm", skin);
         confirmButton.addListener(new ChangeListener() {
             @Override
             public void changed(ChangeEvent event, Actor actor) {
                 // TODO: Send the selected feature to the game controller
                 System.out.println("Feature selected" + selectedFeature);
-                actor.getParent().remove();
+                actor.getParent().remove(); // Closes the window
             }
         });
         this.add(confirmButton).colspan(2).padTop(10).center().row();
-
         this.pack();
         this.setSize(500, 300);
     }
@@ -94,12 +94,14 @@ public class AskWindow extends Window {
     public void draw(Batch batch, float parentAlpha) {
         // Reset size for all ImageButtons
         for (Actor actor : this.buttonTable.getChildren()) {
-            ((ImageButton)actor).setSize(100, 100);
+            ((ImageButton) actor).setSize(100, 100);
         }
+
         // Increase the size of the selected button
         if (selectedFeatureButton != null) {
             selectedFeatureButton.setSize(120, 120);
-        } 
+        }
+
         super.draw(batch, parentAlpha); // Important
     }
 }

--- a/Project/core/src/main/java/View/screen/GameScreenComponents/PlayerBar.java
+++ b/Project/core/src/main/java/View/screen/GameScreenComponents/PlayerBar.java
@@ -5,6 +5,7 @@ import java.util.List;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.assets.AssetManager;
 import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.g2d.Batch;
 import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.ui.Label;
 import com.badlogic.gdx.scenes.scene2d.ui.Skin;
@@ -61,8 +62,8 @@ public class PlayerBar extends Table {
      * Updates the PlayerBar to visually indicate the current player by
      * highlighting its label in green and dimming the others.
      */
-    public void update() {
-
+    @Override
+    public void draw(Batch batch, float parentAlpha) {
         Game game = gameController.getGame();
         List<Player> players = game.getPlayers();
         Player currentPlayer = game.getCurrentPlayer();
@@ -72,11 +73,14 @@ public class PlayerBar extends Table {
                 int playerIndex = players.indexOf(player);
                 Label playerLabel = (Label) this.getChildren().get(playerIndex);
                 if (player == currentPlayer) {
+                    playerLabel.setColor(Color.GREEN);
                     playerLabel.getColor().a = 1f;
                 } else {
+                    playerLabel.setColor(Color.WHITE);
                     playerLabel.getColor().a = 0.3f;
                 }
             }
         }
+        super.draw(batch, parentAlpha); // Important
     }
 }

--- a/Project/core/src/main/java/View/screen/GameScreenComponents/PlayerBar.java
+++ b/Project/core/src/main/java/View/screen/GameScreenComponents/PlayerBar.java
@@ -36,7 +36,6 @@ public class PlayerBar extends Table {
 
         // Create a label for each player and add it to the table
         for (Player player : gameController.getGame().getPlayers()) {
-            Label.LabelStyle labelStyle = new Label.LabelStyle(skin.getFont("button"), Color.BLACK);
             Label playerLabel = new Label(player.getName(), skin, "narration");
             playerLabel.setFontScale(2f);
             this.add(playerLabel).expandX(); // Expand each label equally along the X-axis

--- a/Project/core/src/main/java/View/screen/GameScreenComponents/PlayerBar.java
+++ b/Project/core/src/main/java/View/screen/GameScreenComponents/PlayerBar.java
@@ -2,8 +2,6 @@ package View.screen.GameScreenComponents;
 
 import java.util.List;
 
-import com.badlogic.gdx.Gdx;
-import com.badlogic.gdx.assets.AssetManager;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.g2d.Batch;
 import com.badlogic.gdx.scenes.scene2d.Actor;


### PR DESCRIPTION
### Changes
Me, @mrPaintMan and @Meilin77 have done a lot of thinking and a lot of refactoring today (but I forgot adding them as co-writers to the first commits 😢). We think we’ve figured out a good "recipe" for creating custom widgets and updating their visuals, which can be adopted by all other custom widgets

I tried to explain everything in the description below so that the changes are easier to understand. 
#### Refactoring of View:
* Removed old ask window code from `GameScreen`, that is:
  * `createAskActionWindow()`
  * `askAction()`
  * For-loop creating "Ask", "Move" and "Reveal" buttons
* Extracted a new component `AskWindow` from `AskButton`
* Reduced the number of arguments for `AskButton` from 6 to 2
* Made sure `AskWindow`, `AskButton` and `PlayerBar` use `draw()` for updating visuals
  * The `draw()` method is called automatically every frame **if** the widget has been added to the `stage`
  * This replaces old solutions like:
     * Using a custom made `update()` method
     * Updating the visuals in the action listener
   *  Instead the action listener should only update the variables which the visual updates depend on
* Made some general cleanup removing unused imports and variables
* Added documentation
* Discovered that `getStage()` can be used for accessing the stage to which a widget belongs, this means we don't have to pass the stage as an argument. 
#### Visual changes:
* Removed "Move" and "Reveal" buttons (since they where duplicates of the "Ask" button)
* Made the "Ask" button disabled for temple cells
### Assigned reviewers
* @Joakim-Johansson 
* @Dustfoxx 
