### PR TITLE
Fixed Issue: Game crashes on certain tiles and Recruiter can't move anywhere on initial move

### DIFF
--- a/Project/core/src/main/java/Controller/CheckAction.java
+++ b/Project/core/src/main/java/Controller/CheckAction.java
@@ -217,7 +217,7 @@ public class CheckAction {
      * @param board board is only needed for size
      * @return mask for valid placements of agents
      */
-    public boolean[][] getValidPlacements(Board board) {
+    public boolean[][] getValidPlacements(Player currentPlayer, Board board) {
         int[] dims = board.getDims();
 
         boolean[][] mask = new boolean[dims[0]][dims[1]];
@@ -225,7 +225,7 @@ public class CheckAction {
 
         for (int i = 0; i < dims[0]; i++) {
             for (int j = 0; j < dims[1]; j++) {
-                value = false;
+                value = currentPlayer instanceof Recruiter ? false : true;
                 if (i == 0 || i == dims[0] - 1) {
                     value = true;
                 } else if (j == 0 || j == dims[1] - 1) {
@@ -236,7 +236,6 @@ public class CheckAction {
         }
 
         return mask;
-
     }
 
     /**

--- a/Project/core/src/main/java/Controller/CheckAction.java
+++ b/Project/core/src/main/java/Controller/CheckAction.java
@@ -55,19 +55,10 @@ public class CheckAction {
      * @param maxVal   What the maximum possible coordinate is
      * @return Returns an array of three integers
      */
-    private int[] getCoordRange(int location, int maxVal) {
-        int[] range = { 0, 0 };
-
-        if (location != 0) {
-            range[0] = location - 1;
-        }
-        if (location < maxVal) {
-            range[1] = location + 1;
-        } else {
-            range[1] = maxVal;
-        }
-
-        return range;
+    private int[] getCoordRange(int location, int maxBound) {
+        int start = Math.max(0, location - 1);
+        int end = Math.min(location + 1, maxBound - 1);
+        return new int[] { start, end };
     }
 
     /**

--- a/Project/core/src/main/java/View/screen/GameScreenComponents/MoveButton.java
+++ b/Project/core/src/main/java/View/screen/GameScreenComponents/MoveButton.java
@@ -28,7 +28,7 @@ public class MoveButton extends TextButton {
                 Player currentPlayer = gameController.getGame().getCurrentPlayer();
                 boolean[][] validMoves;
                 if (gameController.getGame().getBoard().getPlayerCoord(currentPlayer) == null) {
-                    validMoves = checkAction.getValidPlacements(gameController.getGame().getBoard());
+                    validMoves = checkAction.getValidPlacements(currentPlayer, gameController.getGame().getBoard());
                 } else {
                     if (currentPlayer instanceof RougeAgent) {
                         validMoves = checkAction.getValidMoves((RougeAgent) currentPlayer,


### PR DESCRIPTION
The issue was due to getcoordrange returning for example 7 if the dimension was 7 instead of the indexed version 7-1. Fixed it and also make getcoordrange a bit easier to deal with by using Math.max and min instead.

It also makes the recruiter able to move anywhere on the board on the first move
