### PR TITLE
Updated visual logic for capture button

### DIFF
--- a/Project/core/src/main/java/View/screen/GameScreenComponents/CaptureButton.java
+++ b/Project/core/src/main/java/View/screen/GameScreenComponents/CaptureButton.java
@@ -1,6 +1,7 @@
 package View.screen.GameScreenComponents;
 
 import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.g2d.Batch;
 import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.ui.Skin;
@@ -8,6 +9,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
 
 import Controller.GameController;
+import Model.AbstractCell;
 import Model.Player;
 import Model.RougeAgent;
 import Controller.GameController.Actions;
@@ -15,7 +17,6 @@ import Controller.GameController.Actions;
 public class CaptureButton extends TextButton {
 
     private final GameController gameController;
-    private Player player;
 
     public CaptureButton(GameController gameController, Skin skin) {
 
@@ -28,7 +29,6 @@ public class CaptureButton extends TextButton {
 
                 // Perform the capture
                 boolean wasCaptureSuccessful = gameController.actionHandler(Actions.CAPTURE);
-                System.out.println("Got here");
 
                 // Create a window displaying the result
                 CaptureWindow window = new CaptureWindow(wasCaptureSuccessful, skin);
@@ -42,13 +42,34 @@ public class CaptureButton extends TextButton {
     }
 
     @Override
+    public Actor hit(float x, float y, boolean touchable) {
+        // This override prevents the button from being clickable when disabled
+        if (this.isDisabled()) {
+            return null;
+        } else {
+            return super.hit(x, y, touchable);
+        }
+    }
+
+    @Override
     public void draw(Batch batch, float parentAlpha) {
-        this.player = gameController.getGame().getCurrentPlayer();
-        // Only draw the button if the current player is a rouge agent
-        if (player.getClass().equals(RougeAgent.class)){
+        Player currentPlayer = gameController.getGame().getCurrentPlayer();
+        if (currentPlayer instanceof RougeAgent) {
+            // Draw the button if it's a rouge agent's turn
+            super.draw(batch, parentAlpha); // Important
+            // Get the cell of the current player
+            AbstractCell currentCell = gameController.getGame().getCurrentPlayerCell();
+            if (currentCell != null) {
+                // Enable the button if current player is placed at board
+                this.setColor(Color.WHITE);
                 this.setDisabled(false);
-                super.draw(batch, parentAlpha);
-        }else{
+            } else {
+                // Disable and shadow the button otherwise
+                this.setColor(0.6f, 0.6f, 0.6f, 1f);
+                this.setDisabled(true);
+            }
+        } else {
+            // Disable the button if it's the recruiter's turn
             this.setDisabled(true);
         }
 


### PR DESCRIPTION
### Changes
- Solved issue with capture button not being shadowed correctly:
   #76 
- Now its:
  - Disabled, untouchable and hidden when its the recruiters turn
  - Disabled, untouchable and shadowed when its the agents turn but they are not currently placed on the board
  - Enabled, touchable and not shadowed when its the agents turn and they are placed on the board
- Also removed an old print
### Reviewer
- @Joakim-Johansson since he is working on similar stuff with another button:
   - #62 
   - #46