### PR TITLE
Recruiter information hidden not on recruiter turn

### DIFF
--- a/Project/core/src/main/java/Controller/GameController.java
+++ b/Project/core/src/main/java/Controller/GameController.java
@@ -163,7 +163,39 @@ public class GameController {
         if (checkAction.isMaskEmpty(gameState.getValidityMask())) {
             gameState.setGameOver();
         }
+        if (gameState.getCurrentPlayer() instanceof Recruiter) {
+            setVisibility(true);
+        } else {
+            setVisibility(false);
+        }
+    }
 
+    /**
+     * Sets the visibility of all steps for the recruiter
+     * 
+     * @param visibility what to set visibility to
+     */
+    private void setVisibility(boolean visibility) {
+        int[] dims = gameState.getBoard().getDims();
+        for (int row = 0; row < dims[0]; row++) {
+            for (int col = 0; col < dims[1]; col++) {
+                AbstractCell cell = gameState.getBoard().getCell(row, col);
+                List<Player> players = cell.getPlayers();
+                List<Token> tokens = cell.getTokens();
+
+                for (Player player : players) {
+                    if (player instanceof Recruiter) {
+                        ((Recruiter) player).setVisibility(visibility);
+                    }
+                }
+
+                for (Token token : tokens) {
+                    if (token instanceof Step) {
+                        ((Step) token).setVisibility(visibility);
+                    }
+                }
+            }
+        }
     }
 
     private void preGameLogic() {

--- a/Project/core/src/main/java/Controller/GameController.java
+++ b/Project/core/src/main/java/Controller/GameController.java
@@ -164,18 +164,18 @@ public class GameController {
             gameState.setGameOver();
         }
         if (gameState.getCurrentPlayer() instanceof Recruiter) {
-            setVisibility(true);
+            setRecruiterVisibility(true);
         } else {
-            setVisibility(false);
+            setRecruiterVisibility(false);
         }
     }
 
     /**
      * Sets the visibility of all steps for the recruiter
-     * 
+     *
      * @param visibility what to set visibility to
      */
-    private void setVisibility(boolean visibility) {
+    private void setRecruiterVisibility(boolean visibility) {
         int[] dims = gameState.getBoard().getDims();
         for (int row = 0; row < dims[0]; row++) {
             for (int col = 0; col < dims[1]; col++) {
@@ -185,13 +185,13 @@ public class GameController {
 
                 for (Player player : players) {
                     if (player instanceof Recruiter) {
-                        ((Recruiter) player).setVisibility(visibility);
+                        player.setVisibility(visibility);
                     }
                 }
 
                 for (Token token : tokens) {
                     if (token instanceof Step) {
-                        ((Step) token).setVisibility(visibility);
+                        token.setVisibility(visibility);
                     }
                 }
             }

--- a/Project/core/src/main/java/Model/BrainFact.java
+++ b/Project/core/src/main/java/Model/BrainFact.java
@@ -17,6 +17,7 @@ public class BrainFact extends Token {
      * @param timestamp The timestamp of the BrainFact token.
      */
     public BrainFact(int timestamp) {
+        super();
         this.timestamp = timestamp;
     }
 

--- a/Project/core/src/main/java/Model/BrainNote.java
+++ b/Project/core/src/main/java/Model/BrainNote.java
@@ -17,6 +17,7 @@ public class BrainNote extends Token {
      * @param note The note of the BrainNote token.
      */
     public BrainNote(String note) {
+        super();
         this.note = note;
     }
 

--- a/Project/core/src/main/java/Model/Player.java
+++ b/Project/core/src/main/java/Model/Player.java
@@ -11,6 +11,7 @@ import java.util.Objects;
 public abstract class Player {
     private int id; // The unique identifier for the player
     private String name; // The name of the player
+    private boolean isVisible;
 
     /**
      * Constructor to initialize a player with a unique ID.
@@ -21,6 +22,7 @@ public abstract class Player {
     public Player(int id) {
         this.id = id;
         this.name = "Player " + id;
+        this.isVisible = true;
     }
 
     /**
@@ -32,6 +34,7 @@ public abstract class Player {
     public Player(int id, String name) {
         this.id = id;
         this.name = name;
+        this.isVisible = true;
     }
 
     /**
@@ -59,6 +62,24 @@ public abstract class Player {
      */
     public String getName() {
         return name;
+    }
+
+    /**
+     * Sets the visibility of the player
+     * 
+     * @param visibility true if visible, false if not
+     */
+    public void setVisibility(boolean visibility) {
+        this.isVisible = visibility;
+    }
+
+    /**
+     * Gets the visibilityvalue of a step
+     * 
+     * @return the visibility of the player
+     */
+    public boolean getVisibility() {
+        return this.isVisible;
     }
 
     @Override

--- a/Project/core/src/main/java/Model/Step.java
+++ b/Project/core/src/main/java/Model/Step.java
@@ -4,30 +4,10 @@ import java.util.Objects;
 
 public class Step extends Token {
     public int timestamp;
-    private boolean isVisible;
 
     public Step(int timestamp) {
         super();
-        this.isVisible = false;
         this.timestamp = timestamp;
-    }
-
-    /**
-     * Sets the visibility of the recruiter
-     * 
-     * @param visibility true if visible, false if not
-     */
-    public void setVisibility(boolean visibility) {
-        this.isVisible = visibility;
-    }
-
-    /**
-     * Gets the visibilityvalue of a step
-     * 
-     * @return the visibility of the player
-     */
-    public boolean getVisibility() {
-        return this.isVisible;
     }
 
     @Override

--- a/Project/core/src/main/java/Model/Step.java
+++ b/Project/core/src/main/java/Model/Step.java
@@ -4,9 +4,30 @@ import java.util.Objects;
 
 public class Step extends Token {
     public int timestamp;
+    private boolean isVisible;
 
     public Step(int timestamp) {
+        super();
+        this.isVisible = false;
         this.timestamp = timestamp;
+    }
+
+    /**
+     * Sets the visibility of the recruiter
+     * 
+     * @param visibility true if visible, false if not
+     */
+    public void setVisibility(boolean visibility) {
+        this.isVisible = visibility;
+    }
+
+    /**
+     * Gets the visibilityvalue of a step
+     * 
+     * @return the visibility of the player
+     */
+    public boolean getVisibility() {
+        return this.isVisible;
     }
 
     @Override

--- a/Project/core/src/main/java/Model/Token.java
+++ b/Project/core/src/main/java/Model/Token.java
@@ -9,6 +9,30 @@ import java.util.Objects;
  */
 public abstract class Token {
 
+    private boolean isVisible;
+
+    public Token() {
+        this.isVisible = true;
+    }
+
+    /**
+     * Sets the visibility of the player
+     * 
+     * @param visibility true if visible, false if not
+     */
+    public void setVisibility(boolean visibility) {
+        this.isVisible = visibility;
+    }
+
+    /**
+     * Gets the visibilityvalue of a step
+     * 
+     * @return the visibility of the player
+     */
+    public boolean getVisibility() {
+        return this.isVisible;
+    }
+
     @Override
     public String toString() {
         return "Token{}";

--- a/Project/core/src/main/java/View/buildingBlocks/VisualCell.java
+++ b/Project/core/src/main/java/View/buildingBlocks/VisualCell.java
@@ -157,7 +157,9 @@ public class VisualCell extends Actor {
     private void updatePlayers() {
         players.clear();
         for (Player player : cellInfo.getPlayers()) {
-            players.add(fetchPlayer(player.getId()));
+            if (player.getVisibility()) {
+                players.add(fetchPlayer(player.getId()));
+            }
         }
     }
 
@@ -167,25 +169,29 @@ public class VisualCell extends Actor {
     private void updateTokens() {
         tokens.clear();
         for (Token token : cellInfo.getTokens()) {
-            if (token instanceof Footstep) {
-                tokens.add(footstep);
-            } else if (token instanceof BrainNote) {
-                tokens.add(brains[0]);
-            } else if (token instanceof BrainFact) {
-                tokens.add(brains[1]);
-            } else {
-                tokens.add(step);
+            if (token.getVisibility()) {
+                if (token instanceof Footstep) {
+                    tokens.add(footstep);
+                } else if (token instanceof BrainNote) {
+                    tokens.add(brains[0]);
+                } else if (token instanceof BrainFact) {
+                    tokens.add(brains[1]);
+                } else {
+                    tokens.add(step);
+                }
             }
         }
     }
 
     /**
      * Initializes the feature dictionary by loading feature mappings.
-     * This dictionary maps each {@link Feature} to its corresponding index in the texture.
-     * It uses the {@link FeatureUtil#initializeFeatureDict()} method to populate the mapping.
+     * This dictionary maps each {@link Feature} to its corresponding index in the
+     * texture.
+     * It uses the {@link FeatureUtil#initializeFeatureDict()} method to populate
+     * the mapping.
      */
     private void initDict() {
-        this.features=FeatureUtil.initializeFeatureDict();
+        this.features = FeatureUtil.initializeFeatureDict();
     }
 
     /**
@@ -193,8 +199,10 @@ public class VisualCell extends Actor {
      * magic numbers to separate them. Should be replaced by atlas
      *
      * @param feature The {@link Feature} to be fetched from the texture.
-     * @return A {@link TextureRegion} containing the image of the specified feature.
-     * @throws IllegalArgumentException If the texture file is missing or the feature is invalid.
+     * @return A {@link TextureRegion} containing the image of the specified
+     *         feature.
+     * @throws IllegalArgumentException If the texture file is missing or the
+     *                                  feature is invalid.
      */
     public TextureRegion fetchFeature(Feature feature) {
         this.featuresImg = new Texture("feature_img.png");

--- a/Project/core/src/test/java/Controller/ActionControllerTests.java
+++ b/Project/core/src/test/java/Controller/ActionControllerTests.java
@@ -24,7 +24,7 @@ public class ActionControllerTests {
 
         for (int i = 0; i < cells.length; i++) {
             for (int j = 0; j < cells[i].length; j++) {
-                cells[i][j] = new NormalCell(new Feature[]{Feature.BILLBOARD, Feature.BOOKSTORE});
+                cells[i][j] = new NormalCell(new Feature[] { Feature.BILLBOARD, Feature.BOOKSTORE });
             }
         }
         board = new Board(cells);
@@ -34,7 +34,7 @@ public class ActionControllerTests {
     void testAsk() {
         // Prepare
         Feature feature = Feature.BILLBOARD;
-        Recruiter recruiter = new Recruiter(0, "", new Feature[]{Feature.BILLBOARD, Feature.BUS, Feature.BOOKSTORE});
+        Recruiter recruiter = new Recruiter(0, "", new Feature[] { Feature.BILLBOARD, Feature.BUS, Feature.BOOKSTORE });
         recruiter.addToWalkedPath(0, 0);
         recruiter.addToWalkedPath(0, 1);
 
@@ -53,22 +53,21 @@ public class ActionControllerTests {
 
     @Test
     void testRevealSingle() {
-        int[] position = {0, 0};
+        int[] position = { 0, 0 };
         AbstractCell cell = board.getCell(position[0], position[1]);
         cell.addToken(new Step(1));
         cell.addToken(new Footstep());
         actionController.reveal(cell);
-        assert(cell.getTokens().size() == 2);
-        assert(!cell.containsFootstep());
-        assertEquals(1, ((BrainFact) cell.getTokens().get(1)).getTimestamp(), 
-        "Expected timestamp to be 1 but was: " + ((BrainFact) cell.getTokens().get(1)).getTimestamp());
+        assert (cell.getTokens().size() == 2);
+        assert (!cell.containsFootstep());
+        assertEquals(1, ((BrainFact) cell.getTokens().get(1)).getTimestamp(),
+                "Expected timestamp to be 1 but was: " + ((BrainFact) cell.getTokens().get(1)).getTimestamp());
     }
 
     @Test
     void testRevealEmpty() {
-        int[] position = {1, 1};
+        int[] position = { 1, 1 };
         AbstractCell cell = board.getCell(position[0], position[1]);
-        actionController.reveal(cell);
-        assert(cell.getTokens().size() == 0);
+        assertThrows(IllegalStateException.class, () -> actionController.reveal(cell));
     }
 }


### PR DESCRIPTION
* Describe what you have done.
  * Added a visibility variable to tokens and players
  * False means they do not get drawn
  * True means they do
  * Function going through the board and updating each token and cell depending on which player is active
  * Visualcell now checks if the visibility value is true
* @mrPaintMan can check to see if this would be easy to implement with multiplayer
