### PR TITLE
No blinking numbers, can always right click

### DIFF
--- a/Project/core/src/main/java/View/buildingBlocks/VisualBoard.java
+++ b/Project/core/src/main/java/View/buildingBlocks/VisualBoard.java
@@ -44,8 +44,10 @@ public class VisualBoard {
                 cell.addListener(new ClickListener(Buttons.LEFT) {
                     @Override
                     public void clicked(InputEvent event, float x, float y) {
-                        int[] cellCoords = getCellClicked(event);
-                        gameInfo.actionHandler(Actions.MOVE, new Object[] { cellCoords[0], cellCoords[1] });
+                        if (gameInfo.getBoardIsActive()) {
+                            int[] cellCoords = getCellClicked(event);
+                            gameInfo.actionHandler(Actions.MOVE, new Object[] { cellCoords[0], cellCoords[1] });
+                        }
                     }
                 });
                 cell.addListener(new ClickListener(Buttons.RIGHT) {

--- a/Project/core/src/main/java/View/screen/GameScreen.java
+++ b/Project/core/src/main/java/View/screen/GameScreen.java
@@ -111,6 +111,7 @@ public class GameScreen implements Screen {
                 try {
                     Game gameState = gson.fromJson(msg, Game.class);
                     gameController.deeplySetGameState(gameState);
+                    gameController.setRecruiterVisibility(gameController.getUserIsRecruiter());
                 } catch (JsonSyntaxException e) {
                     // Handle game end?
                     e.printStackTrace();
@@ -256,7 +257,6 @@ public class GameScreen implements Screen {
 
         // Weird bad way of doing this. Doesn't follow mvc but works for now
         gameController.setBoardActive();
-        boardSection.setTouchable(gameController.getBoardIsActive() ? Touchable.enabled : Touchable.disabled);
         actionBar.setTouchable(gameController.getBoardIsActive() ? Touchable.enabled : Touchable.disabled);
         playerBar.setTouchable(gameController.getBoardIsActive() ? Touchable.enabled : Touchable.disabled);
         if (!gameController.getLocalPlay()) {

--- a/Project/core/src/main/java/View/screen/GameScreenComponents/BrainWindow.java
+++ b/Project/core/src/main/java/View/screen/GameScreenComponents/BrainWindow.java
@@ -75,7 +75,9 @@ public class BrainWindow extends Window {
 
     @Override
     public void draw(Batch batch, float parentAlpha) {
-        if (gameController.getGame().getCurrentPlayer() instanceof Recruiter) {
+        if ((gameController.getUserIsRecruiter() && !gameController.getLocalPlay())
+                || (gameController.getLocalPlay()
+                        && gameController.getGame().getCurrentPlayer() instanceof Recruiter)) {
             brainField.setTouchable(Touchable.disabled);
         } else {
             brainField.setTouchable(Touchable.enabled);


### PR DESCRIPTION
* Describe what you have done.
  * The blinking numbers were due to the polling sending the visibility values of the hosts to the clients and before the clients could update their visibility the render went through. on poll response the values are now locally updated.
  * Made it so that right click is always available for players. 
  * As you can see the changes were very small but effective.
